### PR TITLE
commits

### DIFF
--- a/core/components/getpage/include.getpage.php
+++ b/core/components/getpage/include.getpage.php
@@ -17,7 +17,7 @@ function getpage_buildControls(& $modx, $properties) {
                     $nav['prev'] = getpage_makeUrl($modx, $properties, $page - 1, $pagePrevTpl);
                 }
             }
-            if ($i >= $page - $pageLimit && $i <= $page + $pageLimit) {
+            if (empty($pageLimit) || ($i >= $page - $pageLimit && $i <= $page + $pageLimit)) {
                 if ($i == $page) {
                     $nav[$i] = getpage_makeUrl($modx, $properties, $i, $pageActiveTpl);
                 } else {

--- a/core/components/getpage/snippet.getpage.php
+++ b/core/components/getpage/snippet.getpage.php
@@ -10,7 +10,7 @@ $properties['limit'] = (!empty($_REQUEST['limit']) && ($limit = intval($_REQUEST
 $properties['offset'] = (!empty($properties['limit']) && !empty($properties['page'])) ? ($properties['limit'] * ($properties['page'] - 1)) : 0;
 $properties['totalVar'] = empty($totalVar) ? "total" : $totalVar;
 $properties['total'] = !empty($properties['total']) && $total = intval($properties['total']) ? $total : 0;
-$properties['pageLimit'] = !empty($pageLimit) && ($pageLimit = intval($pageLimit)) ? $pageLimit : 5;
+$properties['pageLimit'] = isset($pageLimit) && is_numeric($pageLimit) ? intval($pageLimit) : 5;
 $properties['element'] = empty($element) ? '' : $element;
 $properties['elementClass'] = empty($elementClass) ? 'modChunk' : $elementClass;
 $properties['pageNavVar'] = empty($pageNavVar) ? 'page.nav' : $pageNavVar;


### PR DESCRIPTION
1. Allow *Tpl parameters to be empty in snippet call
2. needed to bypass default tpls
3. Allow unlimited pages listing. Snippet call: &pageLimit=`0`
4. bypass pagination while still using getPage for the rest of it's features or when used with dynamic page size (up to unlimited).
