### PR TITLE
Fix: multiple using of getPage overwites cache

### DIFF
--- a/core/components/getpage/snippet.getpage.php
+++ b/core/components/getpage/snippet.getpage.php
@@ -40,7 +40,7 @@ if ($properties['page'] == 1 && $properties['pageOneLimit'] !== $properties['act
 }
 
 if ($properties['cache']) {
-    $properties['cachePageKey'] = $modx->resource->getCacheKey() . '/' . $properties['page'] . '/' . md5(http_build_query($modx->request->getParameters() . http_build_query($scriptProperties)));
+    $properties['cachePageKey'] = $modx->resource->getCacheKey() . '/' . $properties['page'] . '/' . md5(http_build_query($modx->request->getParameters()) . http_build_query($scriptProperties));
     $properties['cacheOptions'] = array(
         xPDO::OPT_CACHE_KEY => $properties[xPDO::OPT_CACHE_KEY],
         xPDO::OPT_CACHE_HANDLER => $properties[xPDO::OPT_CACHE_HANDLER],


### PR DESCRIPTION
The getPage's cache becomes overwritten while using
[!getPage&cache=`1` ... ] two or more times on a same page.
Thus we can't use two or more calls to getPage to show
different content (eg. from getResources with different params).

Signed-off-by: Anton Andersen anton.a.andersen@gmail.com
