### PR TITLE
Added "path" as a custom pageNavScheme

### DIFF
--- a/core/components/getpage/include.getpage.php
+++ b/core/components/getpage/include.getpage.php
@@ -39,13 +39,30 @@ function getpage_buildControls(& $modx, $properties) {
 
 function getpage_makeUrl(& $modx, $properties, $pageNo, $tpl) {
     $qs = $properties['qs'];
-    if ($pageNo === 1) {
-        unset($qs[$properties['pageVarKey']]);
-    } else {
-        $qs[$properties['pageVarKey']] = $pageNo;
-    }
     $scheme = !empty($properties['pageNavScheme']) ? $properties['pageNavScheme'] : $modx->getOption('link_tag_scheme', $properties, -1);
-    $properties['href'] = $modx->makeUrl($modx->resource->get('id'), '', $qs, $scheme);
+    
+    if ($properties['pageNavScheme'] === 'path') {
+        
+        unset($qs[$properties['pageVarKey']]);
+        $properties['href'] = $modx->makeUrl($modx->resource->get('id'), '', '', $modx->getOption('link_tag_scheme', $properties, -1));
+        if ($pageNo !== 1) {
+            $properties['href'] = rtrim($properties['href'], '/').$properties['pathUrlSeparator'];
+            if (!$properties['pathHidePageVarKey']) $properties['href'] .= $properties['pageVarKey'].$properties['pathNumberSeparator'];
+            $properties['href'] .= $pageNo;
+        }
+        if (!empty($qs)) $properties['href'] .= '?'. http_build_query($qs);
+        
+    } else {
+        
+        if ($pageNo === 1) {
+            unset($qs[$properties['pageVarKey']]);
+        } else {
+            $qs[$properties['pageVarKey']] = $pageNo;
+        }
+        $properties['href'] = $modx->makeUrl($modx->resource->get('id'), '', $qs, $scheme);
+        
+    }
+    
     $properties['pageNo'] = $pageNo;
     $nav= $modx->newObject('modChunk')->process($properties, $tpl);
     return $nav;

--- a/core/components/getpage/snippet.getpage.php
+++ b/core/components/getpage/snippet.getpage.php
@@ -29,6 +29,9 @@ $properties['pageFirstTpl'] = !isset($pageFirstTpl) ? "<li class=\"control\"><a[
 $properties['pageLastTpl'] = !isset($pageLastTpl) ? "<li class=\"control\"><a[[+title]] href=\"[[+href]]\">Last</a></li>" : $pageLastTpl;
 $properties['pagePrevTpl'] = !isset($pagePrevTpl) ? "<li class=\"control\"><a[[+title]] href=\"[[+href]]\">&lt;&lt;</a></li>" : $pagePrevTpl;
 $properties['pageNextTpl'] = !isset($pageNextTpl) ? "<li class=\"control\"><a[[+title]] href=\"[[+href]]\">&gt;&gt;</a></li>" : $pageNextTpl;
+$properties['pathUrlSeparator'] = !isset($pathUrlSeparator) ? "/" : $pathUrlSeparator;
+$properties['pathNumberSeparator'] = !isset($pathNumberSeparator) ? "-" : $pathNumberSeparator;
+$properties['pathHidePageVarKey'] = !isset($pathHidePageVarKey) ? false : $pathHidePageVarKey;
 $properties['toPlaceholder'] = !empty($toPlaceholder) ? $toPlaceholder : '';
 $properties['cache'] = isset($cache) ? (boolean) $cache : (boolean) $modx->getOption('cache_resource', null, false);
 if (empty($cache_key)) $properties[xPDO::OPT_CACHE_KEY] = $modx->getOption('cache_resource_key', null, 'resource');


### PR DESCRIPTION
Implemented `path` as a custom `pageNavScheme` in getPage, which makes it easy to generated pagination URLs like `/blog/page-2` or `/blog/3` or `/blog/page/4`, so people don't need to use the get parameters.

If `pageNavScheme` is set to `path` the resource URL will be generated using the `link_tag_scheme` setting.

There are 3 new properties to customize the URL generation… `pathUrlSeparator`, `pathNumberSeparator`, `pathHidePageVarKey`.