### PR TITLE
Fix issue #34: log spammed with PHP warnings

### DIFF
--- a/core/components/getpage/include.getpage.php
+++ b/core/components/getpage/include.getpage.php
@@ -32,7 +32,7 @@ function getpage_buildControls(& $modx, $properties) {
                 $nav['last'] = getpage_makeUrl($modx, $properties, $i, $pageLastTpl);
             }
         }
-        $nav['pages'] = implode("\n", $nav['pages']);
+        $nav['pages'] = implode("\n", is_array($nav['pages']) ? $nav['pages'] : array());
     }
     return $nav;
 }


### PR DESCRIPTION
Log is filling with 

```
[2020-03-14 03:32:21] (ERROR @ /var/www/html/core/components/getpage/include.getpage.php : 35) PHP warning: implode(): Invalid arguments passed
[2020-03-14 03:38:14] (ERROR @ /var/www/html/core/components/getpage/include.getpage.php : 35) PHP warning: implode(): Invalid arguments passed
[2020-03-14 03:53:22] (ERROR @ /var/www/html/core/components/getpage/include.getpage.php : 35) PHP warning: implode(): Invalid arguments passed
```

absent this fix under PHP 7.2.