### PR TITLE
Prevent 500 error on implode() call

### DIFF
--- a/core/components/getpage/include.getpage.php
+++ b/core/components/getpage/include.getpage.php
@@ -3,7 +3,9 @@
  * @package getpage
  */
 function getpage_buildControls(& $modx, $properties) {
-    $nav = array();
+    $nav = array(
+        'pages' => array()
+    );
     $qs = !empty($properties['qs']) ? $properties['qs'] : array();
     $page = !empty($properties['page']) ? $properties['page'] : 1;
     $pageCount = !empty($properties['pageCount']) ? $properties['pageCount'] : 1;
@@ -18,7 +20,6 @@ function getpage_buildControls(& $modx, $properties) {
                 }
             }
             if (empty($pageLimit) || ($i >= $page - $pageLimit && $i <= $page + $pageLimit)) {
-                if (!array_key_exists('pages', $nav)) $nav['pages'] = array();
                 if ($i == $page) {
                     $nav['pages'][$i] = getpage_makeUrl($modx, $properties, $i, $pageActiveTpl, 'pageActiveTpl');
                 } else {


### PR DESCRIPTION
It is possible to have no pages if an arbitrary "page" number is set outside the bounds. This fix adjusts the `$nav` variable to initialize `$nav['pages']` sooner to prevent 500 errors on implode() call.